### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/gitguardian.yml
+++ b/.github/workflows/gitguardian.yml
@@ -2,6 +2,9 @@ name: GitGuardian scan
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   scanning:
     name: GitGuardian scan


### PR DESCRIPTION
Potential fix for [https://github.com/jbnance/shepherd-crafted.com/security/code-scanning/2](https://github.com/jbnance/shepherd-crafted.com/security/code-scanning/2)

In general, the fix is to declare an explicit `permissions:` block in the workflow, restricting the `GITHUB_TOKEN` to the minimum necessary scopes. For this GitGuardian scan workflow, the job only needs to read repository contents (for checkout and scanning), so `contents: read` is sufficient unless other, unseen steps are added later that require more.

The best way to fix this without changing existing functionality is to add a `permissions:` block at the workflow (top) level so it applies to all jobs that don’t override it. Insert it after the `on:` section and before `jobs:`. Set it to `contents: read`. This ensures the `GITHUB_TOKEN` cannot perform write operations on repository contents, while still allowing `actions/checkout@v4` and the GitGuardian action to read the code.

Concretely, in `.github/workflows/gitguardian.yml`, between lines 3 (`on: [push, pull_request]`) and 5 (`jobs:`), add:

```yml
permissions:
  contents: read
```

No additional imports, methods, or definitions are needed, since this is just a configuration change in the workflow YAML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
